### PR TITLE
Add search view for hosts, notes and shows.

### DIFF
--- a/program/migrations/0014_add_fulltext_indices.py
+++ b/program/migrations/0014_add_fulltext_indices.py
@@ -5,13 +5,22 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
+    # this works with mysql 5.6, prior to this the engine needs to be MyISAM
+    # changing the engine does not work with 5.5 and the program_show tabl
     dependencies = [
         ("program", "0013_show_and_note_images"),
     ]
 
     operations = [
-        migrations.RunSQL("ALTER TABLE program_host ADD FULLTEXT (name);"),
-        migrations.RunSQL("ALTER TABLE program_note ADD FULLTEXT (title);"),
-        migrations.RunSQL("ALTER TABLE program_show ADD FULLTEXT (name);"),
+        migrations.RunSQL(
+            sql="ALTER TABLE program_host ADD FULLTEXT (name);",
+            reverse_sql="DROP INDEX name ON program_host;"
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE program_note ADD FULLTEXT (title);",
+            reverse_sql="DROP INDEX title ON program_note;"),
+        migrations.RunSQL(
+            sql="ALTER TABLE program_show ADD FULLTEXT (name);",
+            reverse_sql="DROP INDEX name ON program_show;"
+        ),
     ]

--- a/program/migrations/0014_add_fulltext_indices.py
+++ b/program/migrations/0014_add_fulltext_indices.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("program", "0013_show_and_note_images"),
+    ]
+
+    operations = [
+        migrations.RunSQL("ALTER TABLE program_host ADD FULLTEXT (name);"),
+        migrations.RunSQL("ALTER TABLE program_note ADD FULLTEXT (title);"),
+        migrations.RunSQL("ALTER TABLE program_show ADD FULLTEXT (name);"),
+    ]

--- a/program/urls.py
+++ b/program/urls.py
@@ -28,6 +28,8 @@ urlpatterns = patterns('',
                        url(r'^v2/shows/(?P<slug>[\w-]+)/?$', views.ShowDetailViewV2.as_view()),
                        url(r'^v2/(?P<pk>\d+)/?$', views.TimeSlotDetailViewV2.as_view()),
                        url(r'^v2/show-filters/?$', views.ShowFilterListViewV2.as_view()),
+                       # Search view for WordPress 2024
+                       url(r'^v3/search/?$', views.search),
                        )
 if settings.DEBUG:
     urlpatterns += \

--- a/program/views.py
+++ b/program/views.py
@@ -1,8 +1,10 @@
 import json
 from datetime import date, datetime, time, timedelta
+from itertools import chain
 
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic.base import TemplateView
 from django.views.generic.detail import DetailView
@@ -356,3 +358,73 @@ def json_timeslots_specials(request):
 
     return HttpResponse(json.dumps(specials, ensure_ascii=False, encoding='utf8').encode('utf8'),
                         content_type="application/json; charset=utf-8")
+
+# search for WordPress
+
+
+def search(request):
+    q = request.GET.get("q")
+    page = request.GET.get("page")
+    types = request.GET.get("type").split(',') if 'type' in request.GET else None
+
+    if types is None or 'host' in types:
+        hosts = list(
+            Host.objects.filter(name__search=q).values(
+                'id',
+                'name',
+            )
+        )
+    else:
+        hosts = []
+
+    if types is None or 'note' in types:
+        notes = list(
+            Note.objects.filter(title__search=q).select_related('show', 'timeslot').values(
+                'content',
+                'image',
+                'show__image',
+                'show__name',
+                'show__slug',
+                'start',
+                'timeslot',
+                'title',
+            )
+        )
+    else:
+        notes = []
+
+    if types is None or 'show' in types:
+        shows = list(
+            Show.objects.filter(name__search=q).values(
+                'description',
+                'image',
+                'name',
+                'short_description',
+            )
+        )
+    else:
+        shows = []
+
+    # FIXME: this is a very ugly way to "annotate" the results with their type
+    for host in hosts:
+        host['type'] = 'host'
+    for note in notes:
+        note['type'] = 'note'
+    for show in shows:
+        show['type'] = 'show'
+
+    paginator = Paginator(list(chain(hosts, notes, shows)), per_page=10)
+
+    try:
+        page = paginator.page(page)
+    except PageNotAnInteger:
+        page = paginator.page(1)
+    except EmptyPage:
+        page = paginator.page(paginator.num_pages)
+
+    return JsonResponse({
+        'count': paginator.count,
+        'page': page.number,
+        'pages': paginator.num_pages,
+        'results': list(page.object_list),
+    })

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow==3.3.0
 PyYAML==3.11
 django-tinymce==2.6.1
 python-dateutil==2.5.3
+sqlparse==0.3.1


### PR DESCRIPTION
- The migration adds full-text indices on `program_host` (`name`), `program_note` (`title`) and `program_show` (`name`),
- The search can be limited to a specific type or not,
- The view is paginated and returns a list of objects, annotated with their type,
- The view is exposed at `/v3/search/`.

**To apply the migration, `sqlparse` is  required,**

**tested with mysql 5.6, prior versions require the engine to be MyISAM and changing it does not work with mysql 5.5**