### PR TITLE
Simple search view for hosts, notes and shows

### DIFF
--- a/program/urls.py
+++ b/program/urls.py
@@ -28,6 +28,8 @@ urlpatterns = patterns('',
                        url(r'^v2/shows/(?P<slug>[\w-]+)/?$', views.ShowDetailViewV2.as_view()),
                        url(r'^v2/(?P<pk>\d+)/?$', views.TimeSlotDetailViewV2.as_view()),
                        url(r'^v2/show-filters/?$', views.ShowFilterListViewV2.as_view()),
+                       # search view for WordPress 2025
+                       url(r'^v3/search/?$', views.search)
                        )
 if settings.DEBUG:
     urlpatterns += \


### PR DESCRIPTION
- The search is limited to `Host.name`, `Note.title` and `Show.name`  fields,
- The scope of can be narrowed by specifying the `types` query parameter: `host`, `note` or `show`.
- The view is paginated and returns a list of objects, annotated with their type,
- The view is exposed at `/v3/search/` and expects the `q` and handles the `page` parameter.

It doesn’t require any migration, it’s limited because it uses `SELECT ... from ... WHERE ILIKE` for the search.